### PR TITLE
docs: fix quickstart demo links

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,7 +77,7 @@ by supplying the COM port and calibration file path:
 
 ## Quick Start Using the Demo File
 
-The [demo file](https://github.com/ChilasLasers/PyChilasLasers/tree/docs/examples/basic_usage.py) file demonstrates a typical workflow for laser operation.
+The [demo file](https://github.com/ChilasLasers/PyChilasLasers/blob/main/examples/basic_usage.py) demonstrates a typical workflow for laser operation.
 
 ```mermaid
 graph LR
@@ -148,7 +148,7 @@ Access the current wavelength directly via the tune mode interface:
 
 ### 5. COMET‑Only Features (Sweep Mode)
 
-On COMET devices, the script optionally runs the [sweeping demo](https://github.com/ChilasLasers/PyChilasLasers/tree/docs/examples/basic_usage_sweeping.py) showcasing Sweep Mode.
+On COMET devices, the script optionally runs the [sweeping demo](https://github.com/ChilasLasers/PyChilasLasers/blob/main/examples/basic_usage_sweeping.py) showcasing Sweep Mode.
 
 !!! tip "Not using a COMET? You can skip this section."
 


### PR DESCRIPTION
## Summary
Fix the quickstart demo links so they point to the example scripts that exist on `main`.

## Context & Motivation
Fixes: #29
Related: 

The quickstart currently links to `tree/docs/examples/...`, but the demo scripts live in the repository root under `examples/`.

## Changes
- Update the basic demo link to `examples/basic_usage.py` on `main`.
- Update the sweeping demo link to `examples/basic_usage_sweeping.py` on `main`.
- Remove the duplicated `file` word from the touched sentence.

## Type of change
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation only)
- [ ] refactor (no functional change)
- [ ] perf (performance improvement)
- [ ] test (add/modify tests)
- [ ] build (packaging/uv/pyproject)
- [ ] ci (workflows/actions)
- [ ] chore (maintenance)

## Checklist
- [ ] My code follows the [coding conventions](https://github.com/ChilasLasers/DevDocs/blob/main/coding-conventions.md#-class-structure-template) (N/A, docs-only link fix)
- [x] I have checked and updated any relevant diagrams (N/A)
- [x] I have updated the firmware-software compatibility table (N/A)
- [x] I have checked and updated relevant documentation
- [x] I have checked and updated the quickstart guide

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD` passed.
- Confirmed both target example files exist on upstream `main` via the GitHub API.