### PR TITLE
fix docs: correct mode.LaserMode → modes.LaserMode in quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -118,7 +118,7 @@ Power the system and select [`TuneMode`][pychilaslasers.modes.TuneMode] via its 
     laser.system_state = True
 
     # Enter tune mode
-    laser.mode = mode.LaserMode.TUNE
+    laser.mode = modes.LaserMode.TUNE
     ```
 
 ### 3. Wavelength Control Examples


### PR DESCRIPTION
Fixes #30.

1 line fix: corrects the Python import reference in the quickstart guide from `mode.LaserMode.TUNE` (undefined) to `modes.LaserMode.TUNE` (the correct module path per the `pychilaslasers.modes` API). GH007 compliant.